### PR TITLE
fix(deno.json): add the `--env-file=.env.prod` flag to vite:prod task

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -6,7 +6,7 @@
     "seed": "deno run -A --env-file=.env.dev tasks/seed.ts",
     "dev:with-seed": "deno task seed && deno task dev",
     "api:prod": "deno compile -A --env-file=.env.prod --no-check --output dist/api --target x86_64-unknown-linux-gnu --include dist/web api/server.ts --env=prod",
-    "vite:prod": "deno run -A tasks/vite.js --build --env=prod",
+    "vite:prod": "deno run -A --env-file=.env.prod tasks/vite.js --build --env=prod",
     "prod": "deno task vite:prod && deno task api:prod",
     "start:prod": "dist/api --env=prod",
     "fmt": "deno fmt",


### PR DESCRIPTION
This pull request makes a small update to the `deno.json` configuration to ensure that the production build for Vite uses the correct environment variables.

* The `vite:prod` task now includes the `--env-file=.env.prod` flag, ensuring that Vite builds with the production environment settings.