### PR TITLE
Add authorization when fetching deployment /router/metrics (metrics-router)

### DIFF
--- a/api/routes.ts
+++ b/api/routes.ts
@@ -795,6 +795,10 @@ const defs = {
       try {
         return await fetchJson(`${dep.endpoint}/router/metrics`, {
           method: 'GET',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${dep.accessToken}`,
+          },
         })
       } catch (err) {
         log.error('fetch-router-metrics-error', { error: err })


### PR DESCRIPTION
Add authorization header when fetching deployment router metrics